### PR TITLE
Prepare publishing to maven central & prepare 2.2.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It heavily depends on [Android Test Orchestrator](https://medium.com/stepstone-t
 ### 1. Add a Gradle dependency in your `build.gradle`
 
 ```groovy
-implementation 'com.stepstone.xrunner:xrunner-library:2.1.0'
+implementation 'com.stepstone.xrunner:xrunner-library:2.2.0'
 ```
 
 *NOTE:* not on AndroidX yet? See *Compatibility* section at the bottom.
@@ -46,7 +46,7 @@ android {
 }
     
 dependencies {
-    androidTestUtil 'androidx.test:orchestrator:1.2.0'
+    androidTestUtil 'androidx.test:orchestrator:1.4.0'
 }
 ```
 
@@ -85,7 +85,7 @@ Here are some samples:
 
 | XRunner version                                                          | Test runner version                     |
 |:------------------------------------------------------------------------:|:---------------------------------------:|
-| [X.Y.Z](https://github.com/stepstone-tech/AndroidTestXRunner/tree/X.Y.Z) | `androidx.test:runner:1.4.0`            |
+| [2.2.0](https://github.com/stepstone-tech/AndroidTestXRunner/tree/2.2.0) | `androidx.test:runner:1.4.0`            |
 | [2.1.0](https://github.com/stepstone-tech/AndroidTestXRunner/tree/2.1.0) | `androidx.test:runner:1.2.0`            |
 | [2.0.0](https://github.com/stepstone-tech/AndroidTestXRunner/tree/2.0.0) | `androidx.test:runner:1.1.0`            |
 | [1.0.0](https://github.com/stepstone-tech/AndroidTestXRunner/tree/1.0.0) | `com.android.support.test:runner:1.0.2` |

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@ buildscript {
     }
 }
 
+plugins {
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+}
+
 allprojects {
     repositories {
         google()
@@ -45,3 +49,5 @@ configure(allprojects) {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+apply from: "xrunner-library/scripts/publish-root.gradle"

--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -2,17 +2,12 @@
 //
 // kotlin-gradle-plugin must be applied for configuration below to work
 // (see https://kotlinlang.org/docs/reference/using-gradle.html)
-
-repositories {
-    jcenter()
-}
-
 configurations {
     ktlint
 }
 
 dependencies {
-    ktlint "com.pinterest:ktlint:0.34.2"
+    ktlint "com.pinterest:ktlint:0.42.1"
     // additional 3rd party ruleset(s) can be specified here
     // just add them to the classpath (e.g. ktlint 'groupId:artifactId:version') and
     // ktlint will pick them up

--- a/xrunner-library/build.gradle
+++ b/xrunner-library/build.gradle
@@ -31,93 +31,24 @@ dependencies {
 }
 
 ext {
-    bintrayRepo = 'maven'
-    bintrayName = 'android-test-xrunner'
-
-    publishedGroupId = 'com.stepstone.xrunner'
+    artifactGroupId = 'com.stepstone.xrunner'
     libraryName = 'Android Test XRunner'
-    artifact = 'xrunner-library'
+    artifactId = 'xrunner-library'
 
     libraryDescription = 'Running UI tests multiple times made easy'
 
     siteUrl = 'https://github.com/stepstone-tech/AndroidTestXRunner'
-    gitUrl = 'https://github.com/stepstone-tech/AndroidTestXRunner.git'
 
-    libraryVersion = '2.1.0'
+    libraryVersion = '2.2.0'
 
     licenseName = 'The Apache Software License, Version 2.0'
     licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-    allLicenses = ["Apache-2.0"]
 }
 
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    getArchiveClassifier().set("sources")
     from android.sourceSets.main.java.srcDirs
 }
 
-dokkaJavadoc.configure {
-    dokkaSourceSets {
-        named("main") {
-            noAndroidSdkLink.set(false)
-        }
-    }
-}
-
-task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
-    classifier = 'javadoc'
-    from "$buildDir/dokka/javadoc"
-}
-
-publishing {
-    publications {
-        MyPublication(MavenPublication) {
-
-            artifact sourcesJar
-            artifact javadocJar
-            artifact("$buildDir/outputs/aar/xrunner-library-release.aar")
-
-            groupId publishedGroupId
-            artifactId artifact
-            version libraryVersion
-
-            pom {
-                packaging 'aar'
-                withXml {
-
-                    asNode().appendNode('name', libraryName)
-
-                    asNode().appendNode('description', libraryDescription)
-
-                    asNode().appendNode('url', siteUrl)
-
-                    // License
-                    def licensesNode = asNode().appendNode('licenses')
-                    def licenseNode = licensesNode.appendNode('license')
-                    licenseNode.appendNode('name', licenseName)
-                    licenseNode.appendNode('url', licenseUrl)
-
-                    // Git
-                    def scmNode = asNode().appendNode('scm')
-                    scmNode.appendNode('connection', gitUrl)
-                    scmNode.appendNode('developerConnection', gitUrl)
-                    scmNode.appendNode('url', siteUrl)
-
-                    def dependenciesNode = asNode().appendNode('dependencies')
-
-                    // Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
-                    configurations.implementation.allDependencies.each {
-                        // Ensure dependencies such as fileTree are not included.
-                        if (it.name != 'unspecified') {
-                            def dependencyNode = dependenciesNode.appendNode('dependency')
-                            dependencyNode.appendNode('groupId', it.group)
-                            dependencyNode.appendNode('artifactId', it.name)
-                            dependencyNode.appendNode('version', it.version)
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
 publishToMavenLocal.dependsOn 'assembleRelease'
+apply from: "scripts/publish-module.gradle"

--- a/xrunner-library/scripts/publish-module.gradle
+++ b/xrunner-library/scripts/publish-module.gradle
@@ -1,0 +1,92 @@
+// based on https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/
+// & https://gist.github.com/zsmb13/56ed98c8fe916de441f2a9d8e060cd4a
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+apply plugin: 'org.jetbrains.dokka'
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+    from android.sourceSets.main.kotlin.srcDirs
+}
+
+tasks.withType(dokkaHtmlPartial.getClass()).configureEach {
+    pluginsMapConfiguration.set(
+            ["org.jetbrains.dokka.base.DokkaBase": """{ "separateInheritedMembers": true}"""]
+    )
+}
+
+dokkaJavadoc.configure {
+    dokkaSourceSets {
+        named("main") {
+            noAndroidSdkLink.set(false)
+        }
+    }
+}
+
+task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
+    archiveClassifier.set('javadoc')
+    from dokkaJavadoc.outputDirectory
+}
+
+artifacts {
+    archives androidSourcesJar
+    archives javadocJar
+}
+
+group = artifactGroupId
+version = libraryVersion
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                groupId artifactGroupId
+                artifactId artifactId
+                version libraryVersion
+                from components.release
+
+                artifact androidSourcesJar
+                artifact javadocJar
+
+                pom {
+                    name = artifactId
+                    description = libraryDescription
+                    url = siteUrl
+                    licenses {
+                        license {
+                            name = licenseName
+                            url = licenseUrl
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'zawadz88'
+                            name = 'Piotr Zawadzki'
+                            email = 'piotr.zawadzki@stepstone.com'
+                        }
+                        developer {
+                            id = 'RobertZagorski'
+                            name = 'Robert Zagórski'
+                            email = 'robert.zagorski@stepstone.com'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git@github.com:stepstone-tech/AndroidTestXRunner.git'
+                        developerConnection = 'scm:git:ssh://github.com:stepstone-tech/AndroidTestXRunner.git'
+                        url = siteUrl
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    useInMemoryPgpKeys(
+            rootProject.ext["signing.keyId"],
+            rootProject.ext["signing.key"],
+            rootProject.ext["signing.password"],
+    )
+    sign publishing.publications
+}

--- a/xrunner-library/scripts/publish-root.gradle
+++ b/xrunner-library/scripts/publish-root.gradle
@@ -1,0 +1,39 @@
+// based on https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/
+// & https://gist.github.com/zsmb13/56ed98c8fe916de441f2a9d8e060cd4a
+// Create variables with empty default values
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+ext["signing.keyId"] = ''
+ext["signing.password"] = ''
+ext["signing.key"] = ''
+ext["snapshot"] = ''
+
+File secretPropsFile = project.rootProject.file('local.properties')
+if (secretPropsFile.exists()) {
+    // Read local.properties file first if it exists
+    Properties p = new Properties()
+    new FileInputStream(secretPropsFile).withCloseable { is -> p.load(is) }
+    p.each { name, value -> ext[name] = value }
+} else {
+    // Use system environment variables
+    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+    ext["signing.key"] = System.getenv('SIGNING_KEY')
+    ext["snapshot"] = System.getenv('SNAPSHOT')
+}
+
+// Set up Sonatype repository
+nexusPublishing {
+    repositoryDescription = "com.stepstone.xrunner:AndroidTestXRunner"
+    repositories {
+        sonatype {
+            stagingProfileId = sonatypeStagingProfileId
+            username = ossrhUsername
+            password = ossrhPassword
+        }
+    }
+}


### PR DESCRIPTION
Scripts allowing for pushing to remote repository got replaced (Bintray support was removed in  #7 by @zawadz88, added here).
Version 2.2.0 compatible with Orchestrator 1.4.0 is released.